### PR TITLE
[2021123] apply前のslack通知を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
       - attach_workspace:
           at: .
       - install_awscli
-      - install_tfnotify
       - int_and_plan
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,9 @@ workflows:
   build:
     jobs:
       - checkout_code
-      - validate
+      - validate:
+          requires:
+            - checkout_code
       - int_and_plan:
           requires:
             - validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,9 @@ jobs:
           name: notify plan result to slack
           command: |
             cd ./src/tf
-            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan --title "以下のplan結果が反映されます。" --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
+            --title "以下のplan結果が反映されます。" \
+            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:
     executor: 
       name: default
@@ -124,9 +126,7 @@ workflows:
       - int_and_plan:
           requires:
             - validate
-          context: 
-            - TERRAFORM-CI-DEMO
-            - SLACK_INTEGRATION
+          context: TERRAFORM-CI-DEMO
       - notify_before_apply:
           requires:
             - int_and_plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,7 @@ workflows:
       - notify_before_apply:
           requires:
             - int_and_plan
-          context:
-            - TERRAFORM-CI-DEMO
-            - SLACK_INTEGRATION
+          context: TERRAFORM-CI-DEMO
       - hold_apply:
           requires:
             - notify_before_apply

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,20 @@ jobs:
       - attach_workspace:
           at: .
       - install_awscli
-      - int_and_plan
-      - slack_notify
+      - install_tfnotify
+      # - int_and_plan
+      - run:
+          name: notify plan result to slack
+          command: |
+            sh ./bin/assume-role.sh
+            source aws-env.sh
+            cd ./src/tf
+            terraform init -input=false
+            rm -f plan.out plan_notify.out
+            terraform plan -out=plan.out | tfnotify --config ../../.tfnotify/slack.yml plan \
+            --title "以下のplan結果が反映されます。" \
+            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+      # - slack_notify
       - persist_to_workspace:
           root: .
           paths:
@@ -130,25 +142,25 @@ workflows:
           context: 
             - TERRAFORM-CI-DEMO
             - SLACK_INTEGRATION
-      - notify_before_apply:
-          requires:
-            - int_and_plan
-          context:
-            - TERRAFORM-CI-DEMO
-            - SLACK_INTEGRATION
-      - hold_apply:
-          requires:
-            - notify_before_apply
-          type: approval
-          filters:
-            branches:
-              only:
-                - "main"
-      - apply:
-          requires:
-            - hold_apply
-          context: TERRAFORM-CI-DEMO
-          filters:
-            branches:
-              only:
-                - "main"
+      # - notify_before_apply:
+      #     requires:
+      #       - int_and_plan
+      #     context:
+      #       - TERRAFORM-CI-DEMO
+      #       - SLACK_INTEGRATION
+      # - hold_apply:
+      #     requires:
+      #       - notify_before_apply
+      #     type: approval
+      #     filters:
+      #       branches:
+      #         only:
+      #           - "main"
+      # - apply:
+      #     requires:
+      #       - hold_apply
+      #     context: TERRAFORM-CI-DEMO
+      #     filters:
+      #       branches:
+      #         only:
+      #           - "main"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,9 @@ workflows:
       - int_and_plan:
           requires:
             - validate
-          context: TERRAFORM-CI-DEMO
+          context: 
+            - TERRAFORM-CI-DEMO
+            - SLACK_INTEGRATION
       - notify_before_apply:
           requires:
             - int_and_plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,19 +88,7 @@ jobs:
           at: .
       - install_awscli
       - install_tfnotify
-      # - int_and_plan
-      - run:
-          name: notify plan result to slack
-          command: |
-            sh ./bin/assume-role.sh
-            source aws-env.sh
-            cd ./src/tf
-            terraform init -input=false
-            rm -f plan.out plan_notify.out
-            terraform plan -out=plan.out | tfnotify --config ../../.tfnotify/slack.yml plan \
-            --title "以下のplan結果が反映されます。" \
-            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
-      # - slack_notify
+      - int_and_plan
       - persist_to_workspace:
           root: .
           paths:
@@ -116,9 +104,7 @@ jobs:
           name: notify plan result to slack
           command: |
             cd ./src/tf
-            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
-            --title "以下のplan結果が反映されます。" \
-            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan --title "以下のplan結果が反映されます。" --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:
     executor: 
       name: default
@@ -142,25 +128,25 @@ workflows:
           context: 
             - TERRAFORM-CI-DEMO
             - SLACK_INTEGRATION
-      # - notify_before_apply:
-      #     requires:
-      #       - int_and_plan
-      #     context:
-      #       - TERRAFORM-CI-DEMO
-      #       - SLACK_INTEGRATION
-      # - hold_apply:
-      #     requires:
-      #       - notify_before_apply
-      #     type: approval
-      #     filters:
-      #       branches:
-      #         only:
-      #           - "main"
-      # - apply:
-      #     requires:
-      #       - hold_apply
-      #     context: TERRAFORM-CI-DEMO
-      #     filters:
-      #       branches:
-      #         only:
-      #           - "main"
+      - notify_before_apply:
+          requires:
+            - int_and_plan
+          context:
+            - TERRAFORM-CI-DEMO
+            - SLACK_INTEGRATION
+      - hold_apply:
+          requires:
+            - notify_before_apply
+          type: approval
+          filters:
+            branches:
+              only:
+                - "main"
+      - apply:
+          requires:
+            - hold_apply
+          context: TERRAFORM-CI-DEMO
+          filters:
+            branches:
+              only:
+                - "main"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ jobs:
           command: |
             cd ./src/tf
             cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
-            --title "以下のplan結果が反映されます。" \
-            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+            --title "test" \
+            --message "test"
   apply:
     executor: 
       name: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Project Link:*\n${CIRCLE_REPOSITORY_URL}"
+                      "text": "*Project:*\n${CIRCLE_PROJECT_REPONAME}"
                     }
                   ]
                 }
@@ -128,8 +128,6 @@ jobs:
           at: .
       - install_awscli
       - int_and_plan
-      - notify_slack_deploy_pass
-      - notify_slack_deploy_fail
       - persist_to_workspace:
           root: .
           paths:
@@ -142,12 +140,8 @@ jobs:
           at: .
       - install_awscli
       - apply
-      - slack/notify:
-          event: pass
-          template: success_tagged_deploy_1
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
+      - notify_slack_deploy_pass
+      - notify_slack_deploy_fail
 
 workflows:
   version: 2
@@ -160,9 +154,7 @@ workflows:
       - int_and_plan:
           requires:
             - validate
-          context:
-            - TERRAFORM-CI-DEMO
-            - SLACK_INTEGRATION
+          context: TERRAFORM-CI-DEMO
       - slack/on-hold:
           context: SLACK_INTEGRATION
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ commands:
       - run:
           name: install tfnotify
           command: |
-            apk update && apk add --no-cache go libc-dev
-            go version
-            go get -u -v github.com/mercari/tfnotify
+            wget https://github.com/mercari/tfnotify/releases/download/v0.7.0/tfnotify_linux_amd64.tar.gz
+            tar xzf tfnotify_linux_amd64.tar.gz
+            mv tfnotify /usr/local/bin/
   validate:
     steps:
       - run:
@@ -40,8 +40,8 @@ commands:
             source aws-env.sh
             cd ./src/tf
             terraform init -input=false
-            rm -f plan.out
-            terraform plan -out=plan.out
+            rm -f plan.out plan_notify.out
+            terraform plan -out=plan.out | tee plan_notify.out
   apply:
     steps:
       - run:
@@ -92,7 +92,7 @@ jobs:
           name: notify plan result to slack
           command: |
             cd ./src/tf
-            cat plan.out | tfnotify --config .tfnotify/slack.yml plan \
+            cat plan_notify.out | tfnotify --config ../../tfnotify/slack.yml plan \
             --title "以下のplan結果が反映されます。" \
             --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@4.4.4
+
 executors:
   default:
     docker:
@@ -51,6 +54,14 @@ commands:
             source aws-env.sh
             cd ./src/tf
             terraform apply -auto-approve plan.out
+  slack_notify:
+    steps:
+      - slack/notify:
+          event: pass
+          template: basic_success_1
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
 
 jobs:
   checkout_code:
@@ -77,6 +88,7 @@ jobs:
           at: .
       - install_awscli
       - int_and_plan
+      - slack_notify
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "$(TZ=Asia/Tokyo date +'%Y/%m/%d')本番リリースに成功しました:クラッカー:"
+                    "text": "## :tada: $(TZ=Asia/Tokyo date +'%Y/%m/%d') 本番デプロイが完了しました :tada:"
                   }
                 },
                 {
@@ -135,10 +135,7 @@ workflows:
           context: SLACK_INTEGRATION
           requires:
             - int_and_plan
-          filters:
-            branches:
-              ignore:
-                - /.*/
+          branch_pattern: "main"
       - hold_apply:
           requires:
             - int_and_plan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
             source aws-env.sh
             cd ./src/tf
             terraform init -input=false
-            rm -f plan.out plan_notify.out
+            rm -f plan.out
             terraform plan -out=plan.out
   apply:
     steps:
@@ -108,7 +108,9 @@ workflows:
       - int_and_plan:
           requires:
             - validate
-          context: TERRAFORM-CI-DEMO
+          context:
+            - TERRAFORM-CI-DEMO
+            - SLACK_INTEGRATION
       - slack/on-hold:
           context: SLACK_INTEGRATION
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,8 @@ jobs:
           command: |
             cd ./src/tf
             cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
-            --title "test" \
-            --message "test"
+            --title "以下のplan結果が反映されます。" \
+            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:
     executor: 
       name: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.4.4
+  slack: circleci/slack@4.5.0
 
 executors:
   default:
@@ -18,14 +18,6 @@ commands:
             apk --update-cache add python3 py3-pip alpine-sdk
             sudo pip3 install awscli --upgrade
             sudo aws --version
-  install_tfnotify:
-    steps:
-      - run:
-          name: install tfnotify
-          command: |
-            wget https://github.com/mercari/tfnotify/releases/download/v0.7.0/tfnotify_linux_amd64.tar.gz
-            tar xzf tfnotify_linux_amd64.tar.gz
-            mv tfnotify /usr/local/bin/
   validate:
     steps:
       - run:
@@ -44,7 +36,7 @@ commands:
             cd ./src/tf
             terraform init -input=false
             rm -f plan.out plan_notify.out
-            terraform plan -out=plan.out | tee plan_notify.out
+            terraform plan -out=plan.out
   apply:
     steps:
       - run:
@@ -54,14 +46,6 @@ commands:
             source aws-env.sh
             cd ./src/tf
             terraform apply -auto-approve plan.out
-  slack_notify:
-    steps:
-      - slack/notify:
-          event: pass
-          template: basic_success_1
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
 
 jobs:
   checkout_code:
@@ -88,24 +72,16 @@ jobs:
           at: .
       - install_awscli
       - int_and_plan
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
       - persist_to_workspace:
           root: .
           paths:
             - .
-  notify_before_apply:
-    executor: 
-      name: default
-    steps:
-      - attach_workspace:
-          at: .
-      - install_tfnotify
-      - run:
-          name: notify plan result to slack
-          command: |
-            cd ./src/tf
-            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
-            --title "以下のplan結果が反映されます。" \
-            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:
     executor: 
       name: default
@@ -114,6 +90,12 @@ jobs:
           at: .
       - install_awscli
       - apply
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
 
 workflows:
   version: 2
@@ -127,13 +109,18 @@ workflows:
           requires:
             - validate
           context: TERRAFORM-CI-DEMO
-      - notify_before_apply:
+      - slack/on-hold:
+          context: SLACK_INTEGRATION
           requires:
             - int_and_plan
-          context: TERRAFORM-CI-DEMO
+          filters:
+            branches:
+              ignore:
+                - /.*/
       - hold_apply:
           requires:
-            - notify_before_apply
+            - int_and_plan
+            - slack/on-hold
           type: approval
           filters:
             branches:
@@ -142,7 +129,9 @@ workflows:
       - apply:
           requires:
             - hold_apply
-          context: TERRAFORM-CI-DEMO
+          context:
+            - TERRAFORM-CI-DEMO
+            - SLACK_INTEGRATION
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,29 +9,28 @@ commands:
   install_awscli:
     steps:
       - run:
-          name: install_awscli
+          name: install awscli
           command: |
             apk add sudo jq 
             apk --update-cache add python3 py3-pip alpine-sdk
             sudo pip3 install awscli --upgrade
             sudo aws --version
-  init:
+  install_tfnotify:
     steps:
       - run:
-          name: terraform init
+          name: install tfnotify
           command: |
-            sh ./bin/assume-role.sh
-            source aws-env.sh
-            cd ./src/tf
-            terraform init -input=false
+            apk --update-cache add go libc-dev
+            go get -u -v github.com/mercari/tfnotify
   validate:
     steps:
       - run:
           name: terraform validate
           command: |
             cd ./src/tf
+            terraform init -backend=false
             terraform validate
-  plan:
+  int_and_plan:
     steps:
       - run:
           name: terraform plan
@@ -39,6 +38,7 @@ commands:
             sh ./bin/assume-role.sh
             source aws-env.sh
             cd ./src/tf
+            terraform init -input=false
             rm -f plan.out
             terraform plan -out=plan.out
   apply:
@@ -52,23 +52,11 @@ commands:
             terraform apply -auto-approve plan.out
 
 jobs:
-  checkout:
+  checkout_code:
     executor: 
       name: default
     steps:
       - checkout
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-  init:
-    executor: 
-      name: default
-    steps:
-      - attach_workspace:
-          at: .
-      - install_awscli
-      - init
       - persist_to_workspace:
           root: .
           paths:
@@ -80,18 +68,32 @@ jobs:
       - attach_workspace:
           at: .
       - validate
-  plan:
+  int_and_plan:
     executor: 
       name: default
     steps:
       - attach_workspace:
           at: .
       - install_awscli
-      - plan
+      - int_and_plan
       - persist_to_workspace:
           root: .
           paths:
             - .
+  notify_before_apply:
+    executor: 
+      name: default
+    steps:
+      - attach_workspace:
+          at: .
+      - install_tfnotify
+      - run:
+          name: notify plan result to slack
+          command: |
+            cd ./src/tf
+            cat plan.out | tfnotify --config .tfnotify/slack.yml plan \
+            --title "以下のplan結果が反映されます。" \
+            --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:
     executor: 
       name: default
@@ -105,21 +107,21 @@ workflows:
   version: 2
   build:
     jobs:
-      - checkout
-      - init:
-          requires:
-            - checkout
-          context: TERRAFORM-CI-DEMO
-      - validate:
-          requires:
-            - init
-      - plan:
+      - checkout_code
+      - validate
+      - int_and_plan:
           requires:
             - validate
           context: TERRAFORM-CI-DEMO
+      - notify_before_apply:
+          requires:
+            - int_and_plan
+          context:
+            - TERRAFORM-CI-DEMO
+            - SLACK_INTEGRATION
       - hold_apply:
           requires:
-            - plan
+            - notify_before_apply
           type: approval
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Project:*\n${CIRCLE_PROJECT_REPONAME}"
+                      "text": "*Project Link:*\n${CIRCLE_REPOSITORY_URL}"
                     }
                   ]
                 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,62 @@ commands:
             source aws-env.sh
             cd ./src/tf
             terraform apply -auto-approve plan.out
+  # notify to slack
+  notify_slack_deploy_pass:
+    steps:
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":tada: $(TZ=Asia/Tokyo date +'%Y/%m/%d') インフラ本番反映が完了しました :tada:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:*\n${CIRCLE_PROJECT_REPONAME}"
+                    }
+                  ]
+                }
+              ]
+            }
+  notify_slack_deploy_fail:
+    steps:
+      - slack/notify:
+          event: fail
+          mentions: "@tatsukoni1818"
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":small_red_triangle: インフラ本番反映に失敗しました。詳細を確認してください :small_red_triangle:"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${CIRCLE_BUILD_URL}"
+                    }
+                  ]
+                }
+              ]
+            }
 
 jobs:
   checkout_code:
@@ -72,32 +128,8 @@ jobs:
           at: .
       - install_awscli
       - int_and_plan
-      - slack/notify:
-          event: pass
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "## :tada: $(TZ=Asia/Tokyo date +'%Y/%m/%d') 本番デプロイが完了しました :tada:"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Project:*\n${CIRCLE_PROJECT_REPONAME}"
-                    }
-                  ]
-                }
-              ]
-            }
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
+      - notify_slack_deploy_pass
+      - notify_slack_deploy_fail
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,27 @@ jobs:
       - int_and_plan
       - slack/notify:
           event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "(TZ=Asia/Tokyo date +'%Y/%m/%d')本番リリースに成功しました:クラッカー:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:*\n${CIRCLE_PROJECT_REPONAME}"
+                    }
+                  ]
+                }
+              ]
+            }
           template: success_tagged_deploy_1
       - slack/notify:
           event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "(TZ=Asia/Tokyo date +'%Y/%m/%d')本番リリースに成功しました:クラッカー:"
+                    "text": "$(TZ=Asia/Tokyo date +'%Y/%m/%d')本番リリースに成功しました:クラッカー:"
                   }
                 },
                 {
@@ -95,7 +95,6 @@ jobs:
                 }
               ]
             }
-          template: success_tagged_deploy_1
       - slack/notify:
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: notify plan result to slack
           command: |
             cd ./src/tf
-            cat plan_notify.out | tfnotify --config ../../tfnotify/slack.yml plan \
+            cat plan_notify.out | tfnotify --config ../../.tfnotify/slack.yml plan \
             --title "以下のplan結果が反映されます。" \
             --message "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
   apply:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ commands:
       - run:
           name: install tfnotify
           command: |
-            apk --update-cache add go libc-dev
+            apk --update add go libc-dev
+            go version
             go get -u -v github.com/mercari/tfnotify
   validate:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
       - run:
           name: install tfnotify
           command: |
-            apk --update add go libc-dev
+            apk update && apk add --no-cache go libc-dev
             go version
             go get -u -v github.com/mercari/tfnotify
   validate:

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -6,9 +6,9 @@ notifier:
     channel: $SLACK_CHANNEL_ID
     bot: $SLACK_BOT_NAME
 terraform:
+  use_raw_output: true
   plan:
     template: |
-      {{ .Title }}
       {{ .Message }}
       {{ .Link }}
       {{if .Result}}

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -4,7 +4,7 @@ notifier:
   slack:
     token: $SLACK_ACCESS_TOKEN
     channel: $SLACK_DEFAULT_CHANNEL
-    bot: "@circleci"
+    bot: $SLACK_BOT_NAME
 terraform:
   plan:
     template: |

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -4,7 +4,7 @@ notifier:
   slack:
     token: $SLACK_ACCESS_TOKEN
     channel: $SLACK_DEFAULT_CHANNEL
-    bot: $SLACK_BOT_NAME
+    bot: "circleci"
 terraform:
   plan:
     template: |

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -2,7 +2,7 @@
 ci: circleci
 notifier:
   slack:
-    token: $SLACK_ACCESS_TOKEN
+    token: $SLACK_TOKEN
     channel: $SLACK_DEFAULT_CHANNEL
     bot: $SLACK_BOT_NAME
 terraform:

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -8,7 +8,9 @@ notifier:
 terraform:
   plan:
     template: |
+      {{ .Title }}
       {{ .Message }}
+      {{ .Link }}
       {{if .Result}}
       ```
       {{ .Result }}

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -4,7 +4,7 @@ notifier:
   slack:
     token: $SLACK_ACCESS_TOKEN
     channel: $SLACK_DEFAULT_CHANNEL
-    bot: "circleci"
+    bot: "@circleci"
 terraform:
   plan:
     template: |

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -4,7 +4,7 @@ notifier:
   slack:
     token: $SLACK_ACCESS_TOKEN
     channel: $SLACK_DEFAULT_CHANNEL
-    bot: "test-name"
+    bot: $SLACK_BOT_NAME
 terraform:
   plan:
     template: |

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -1,0 +1,19 @@
+---
+ci: circleci
+notifier:
+  slack:
+    token: $SLACK_ACCESS_TOKEN
+    channel: $SLACK_DEFAULT_CHANNEL
+    bot: "test-name"
+terraform:
+  plan:
+    template: |
+      {{ .Message }}
+      {{if .Result}}
+      ```
+      {{ .Result }}
+      ```
+      {{end}}
+      ```
+      {{ .Body }}
+      ```

--- a/.tfnotify/slack.yml
+++ b/.tfnotify/slack.yml
@@ -3,7 +3,7 @@ ci: circleci
 notifier:
   slack:
     token: $SLACK_TOKEN
-    channel: $SLACK_DEFAULT_CHANNEL
+    channel: $SLACK_CHANNEL_ID
     bot: $SLACK_BOT_NAME
 terraform:
   plan:

--- a/src/tf/main.tf
+++ b/src/tf/main.tf
@@ -1,5 +1,5 @@
-# module "ec2" {
-#     source = "../modules/ec2"
-#     instance_type = "t2.micro"
-#     ami_id = "ami-0c07ed1dc0cea3608"
-# }
+module "ec2" {
+    source = "../modules/ec2"
+    instance_type = "t2.micro"
+    ami_id = "ami-0c07ed1dc0cea3608"
+}

--- a/src/tf/main.tf
+++ b/src/tf/main.tf
@@ -1,5 +1,5 @@
-module "ec2" {
-    source = "../modules/ec2"
-    instance_type = "t2.micro"
-    ami_id = "ami-0c07ed1dc0cea3608"
-}
+# module "ec2" {
+#     source = "../modules/ec2"
+#     instance_type = "t2.micro"
+#     ami_id = "ami-0c07ed1dc0cea3608"
+# }


### PR DESCRIPTION
slack通知を追加。
slack orbsを利用している。
tfnotifyの利用を検討したが、上手く挙動しなかったので断念。

# 参考
- https://dev.classmethod.jp/articles/circleci-orbs-notify-slack/#toc-8
- https://circleci.com/developer/ja/orbs/orb/circleci/slack?version=4.5.0
- https://github.com/CircleCI-Public/slack-orb/wiki
- https://app.slack.com/block-kit-builder/TJ4QAAXNC